### PR TITLE
Config refactoring

### DIFF
--- a/entrypoint.py
+++ b/entrypoint.py
@@ -64,16 +64,31 @@ def runDestroy(opts: dict) -> None:
 
 def main() -> None:
     parser = argparse.ArgumentParser()
-    parser.add_argument("action", help="The action to perform", choices=["create", "preview", "destroy", "debug"])
-    parser.add_argument("type", help="The type of infra to create", choices=["site"])
-    parser.add_argument("-o", "--options", help="A comma-separated list of optional settings to use with --type", default="")
-    parser.add_argument("-q", "--quiet", help="Reduces output (hides the various terraform run stages i.e. init, plan, apply)", action="count", default=0)
-    parser.add_argument("-r", "--region", help="The region to use for the provider")
-    parser.add_argument("-e", "--backend", help="The type of backend to use for terraform state", choices=["local", "s3"])
-    parser.add_argument("-p", "--path", help="The path to use when using a local state backend")
-    parser.add_argument("-b", "--bucket", help="An S3 bucket to use for remote state")
-    parser.add_argument("--bucket-region", help="The S3 bucket region to use for the remote state")
-    parser.add_argument("-s", "--state-name", help="A custom name to use for the state file")
+    parser.add_argument("action",
+        help="The action to perform",
+        choices=["create", "preview", "destroy", "debug"])
+
+    parser.add_argument("type",
+        help="The type of infra to create",
+        choices=["site"])
+
+    parser.add_argument("options",
+        help="A comma-separated list of settings to use alongside the 'type' argument",
+        default="domain_name=example.com")
+
+    parser.add_argument("-b", "--backend-options",
+        help="A comma-separated list of configurion parameters for the terraform backend",
+        default="type=local,path=/state/terraform.tfstate")
+
+    parser.add_argument("-r", "--region",
+        help="The region to use for the provider",
+        default='us-east-1')
+
+    parser.add_argument("-q", "--quiet",
+        help="Reduces output (hides the various terraform run stages i.e. init, plan, etc.)",
+        action="count",
+        default=0)
+
     # TODO: implement
     # parser.add_argument("-w", "--workspace", help="A custom workspace name")
 

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -28,19 +28,13 @@ def runCreate(opts: dict) -> None:
     work_dir = opts.get('work_dir', '.')
     quiet = opts.get('quiet', -1)
 
-    # run terraform init, workspace opts if not n/a, and plan/apply
     init_args = ["terraform", f"-chdir={work_dir}", "init"]
-
-    runBaseCmd(init_args, quiet >= 1)
-
-    # run plan
     plan_args = ["terraform", f"-chdir={work_dir}", "plan"]
-
-    runBaseCmd(plan_args, quiet >= 2)
-
-    # run apply
     apply_args = ["terraform", f"-chdir={work_dir}", "apply", "-auto-approve"]
 
+    # run init, plan, and apply
+    runBaseCmd(init_args, quiet >= 1)
+    runBaseCmd(plan_args, quiet >= 2)
     runBaseCmd(apply_args, quiet >= 3)
 
 
@@ -48,14 +42,11 @@ def runPreview(opts: dict) -> None:
     work_dir =  opts.get('work_dir', '.')
     quiet = opts.get('quiet', -1)
 
-    # run terraform init, workspace opts if not n/a, and plan
     init_args = ["terraform", f"-chdir={work_dir}", "init"]
-
-    runBaseCmd(init_args, quiet >= 1)
-
-    # run plan
     plan_args = ["terraform", f"-chdir={work_dir}", "plan"]
 
+    # run init and plan
+    runBaseCmd(init_args, quiet >= 1)
     runBaseCmd(plan_args, quiet >= 2)
 
 
@@ -63,14 +54,11 @@ def runDestroy(opts: dict) -> None:
     work_dir =  opts.get('work_dir', '.')
     quiet = opts.get('quiet', -1)
 
-    # run terraform init, workspace opts if not n/a, and plan/apply
     init_args = ["terraform", f"-chdir={work_dir}", "init"]
-
-    runBaseCmd(init_args, quiet >= 1)
-
-    # run destroy
     destroy_args = ["terraform", f"-chdir={work_dir}", "destroy", "-auto-approve"]
 
+    # run init and destroy
+    runBaseCmd(init_args, quiet >= 1)
     runBaseCmd(destroy_args, quiet >= 2)
 
 


### PR DESCRIPTION
As much as I want to have a rich config interface for this, there are going to be endless use-cases and scenarios depending on what a given end user wants to do with this tool, so I'm opting to keep it simple and leave it to the end user to massage the config functionality to their needs.

- Remove kludgey defaults structure
- Simplify parser arguments
- Clean up a few things here and there to reduce line count and improve readability